### PR TITLE
Modify target to define ram size in yotta config

### DIFF
--- a/target.json
+++ b/target.json
@@ -2,7 +2,7 @@
   "name": "mkit-gcc",
   "version": "0.0.9",
   "inherits": {
-    "nordic-nrf51822-gcc": "*"
+    "nordic-nrf51822-gcc": "^0.0.1"
   },
   "description": "Official mbed build target for the nrf51822 16KB chip.",
   "homepage": "https://github.com/ARMmbed/target-mkit-gcc",

--- a/target.json
+++ b/target.json
@@ -2,7 +2,7 @@
   "name": "mkit-gcc",
   "version": "0.0.9",
   "inherits": {
-    "nordic-nrf51822-16k-gcc": "*"
+    "nordic-nrf51822-gcc": "*"
   },
   "description": "Official mbed build target for the nrf51822 16KB chip.",
   "homepage": "https://github.com/ARMmbed/target-mkit-gcc",
@@ -24,6 +24,14 @@
     "mkit"
   ],
   "config": {
+    "nrf51822": {
+        "ram_size": "16K"
+    },
+    "image": {
+      "heap": {
+        "warning_threshold": 1024
+      }
+    },
     "hardware": {
       "pins": {
         "LED1": "p18",


### PR DESCRIPTION
This target also makes use of the new family target nordic-nrf51822-gcc.